### PR TITLE
#21 - this fixes the issue for me.

### DIFF
--- a/lib/mysql-native/serializers/reader.js
+++ b/lib/mysql-native/serializers/reader.js
@@ -64,7 +64,7 @@ reader.prototype.unpackBinaryDateTime = function()
     var millisec = (length > 8) ? this.num(4) : 0;
     var dt = new Date();
     dt.setYear(y);
-    dt.setMonth(m); 
+    dt.setMonth(m - 1); // months are zero-based in Javascript
     dt.setDate(d);
     dt.setHours(hour);
     dt.setMinutes(min);
@@ -80,7 +80,7 @@ reader.prototype.unpackBinaryDate = function()
        return zeroTime();
 
     var y = this.num(2);
-    var m = this.num(1);
+    dt.setMonth(m - 1); // months are zero-based in Javascript
     var d = this.num(1);
     var dt = new Date();
     dt.setYear(y);


### PR DESCRIPTION
I was unable to add a test for this.  

I managed to install expresso, but saw strange behaviour.  Firstly expresso was not on my path - is this a change in npm 1.0?

I edited select.test.js a few times, and was able to get a failure by inserting "assert.ok(false)" outside of the rows listener.

I eventually discovered that all of the tests are passing because no rows are being returned.

Is there a guide to setting up the tests?  I'm assuming that a MySQL database needs to be set up, possible with some test data.

Thanks,

Chris.
