### PR TITLE
Fixed parsing of large numbers, and bit field support

### DIFF
--- a/lib/mysql-native/commands/execute.js
+++ b/lib/mysql-native/commands/execute.js
@@ -95,8 +95,11 @@ function execPrepared(sql, parameters)
 
           for (var i = 0; i < parameters.length; i++)
           {
-            if (parameters[i] != null && parameters[i] != undefined)
+            if (parameters[i] !== null && parameters[i] !== undefined)
             {
+              if(typeof parameters[i] == "boolean" || (parameters[i] instanceof Array && parameters[i].every(function(x){return typeof x == 'boolean';}))){
+                packet.lcbits(parameters[i]);
+              }
               packet.lcstring(parameters[i].toString())
             }
           }

--- a/lib/mysql-native/commands/query.js
+++ b/lib/mysql-native/commands/query.js
@@ -37,6 +37,7 @@ function parseNumber(s, type) {
       case types.MYSQL_TYPE_LONG:
       case types.MYSQL_TYPE_LONGLONG:
       case types.MYSQL_TYPE_INT24:
+      case types.MYSQL_TYPE_BIT:
         return parseInt(s)
         break;
       case types.MYSQL_TYPE_FLOAT:
@@ -54,17 +55,17 @@ var type_parsers = {};
   type_parsers[types.MYSQL_TYPE_LONG] = parseNumber;
   type_parsers[types.MYSQL_TYPE_FLOAT] = parseNumber;
   type_parsers[types.MYSQL_TYPE_DOUBLE] = parseNumber;
-  type_parsers[types.MYSQL_TYPE_NULL] = parseNull,
-  type_parsers[types.MYSQL_TYPE_TIMESTAMP] = parseTime,
+  type_parsers[types.MYSQL_TYPE_NULL] = parseNull;
+  type_parsers[types.MYSQL_TYPE_TIMESTAMP] = parseTime;
   type_parsers[types.MYSQL_TYPE_LONGLONG] = parseNumber;
   type_parsers[types.MYSQL_TYPE_INT24] = parseNumber;
-  type_parsers[types.MYSQL_TYPE_DATE] = parseTime,
-  type_parsers[types.MYSQL_TYPE_TIME] = parseTime,
-  type_parsers[types.MYSQL_TYPE_DATETIME] = parseTime,
-  type_parsers[types.MYSQL_TYPE_YEAR] = parseTime,
-  type_parsers[types.MYSQL_TYPE_NEWDATE] = parseTime,
+  type_parsers[types.MYSQL_TYPE_DATE] = parseTime;
+  type_parsers[types.MYSQL_TYPE_TIME] = parseTime;
+  type_parsers[types.MYSQL_TYPE_DATETIME] = parseTime;
+  type_parsers[types.MYSQL_TYPE_YEAR] = parseTime;
+  type_parsers[types.MYSQL_TYPE_NEWDATE] = parseTime;
   type_parsers[types.MYSQL_TYPE_VARCHAR] = parseString;
-  //MYSQL_TYPE_BIT: ,
+  type_parsers[types.MYSQL_TYPE_BIT] = parseNumber;
   //MYSQL_TYPE_NEWDECIMAL: 246,
   //MYSQL_TYPE_ENUM: 247,
   //MYSQL_TYPE_SET: 248,

--- a/lib/mysql-native/serializers/reader.js
+++ b/lib/mysql-native/serializers/reader.js
@@ -169,7 +169,7 @@ reader.prototype.num = function(numbytes)
     for (var i=0; i < numbytes; ++i)
     {
         res += this.data.charCodeAt(this.pos) * factor;
-        factor = factor << 8;
+        factor = factor * 256;
         this.pos++;
     }
     return res;

--- a/lib/mysql-native/serializers/reader.js
+++ b/lib/mysql-native/serializers/reader.js
@@ -235,8 +235,16 @@ reader.prototype.lcstring = function()
 reader.prototype.lcbits = function()
 {
     var len = this.lcnum();
-    var res = this.num(len);
-    return res;
+    var val = this.num(len);
+    var bitstring = [];
+    while(val>0){
+        bitstring.push((val % 2)?true:false);
+        val = Math.floor(val/2);
+    }
+    if(bitstring.length==1){
+        return bitstring[0];
+    }
+    return bitstring;
 }
 
 reader.prototype.isEOFpacket = function()

--- a/lib/mysql-native/serializers/reader.js
+++ b/lib/mysql-native/serializers/reader.js
@@ -137,6 +137,9 @@ reader.prototype.unpackBinary = function(type, unsigned)
     case constants.types.MYSQL_TYPE_DOUBLE:
         result = parseIEEE754Double(this.data);
         break;
+    case constants.types.MYSQL_TYPE_BIT:
+        result = this.lcbits();
+        break;
 /*
   MYSQL_TYPE_TIMESTAMP: 7,
   MYSQL_TYPE_LONGLONG: 8,
@@ -226,6 +229,13 @@ reader.prototype.lcstring = function()
 {
     var len = this.lcnum();
     var res = this.bytes(len);
+    return res;
+}
+
+reader.prototype.lcbits = function()
+{
+    var len = this.lcnum();
+    var res = this.num(len);
     return res;
 }
 

--- a/lib/mysql-native/serializers/writer.js
+++ b/lib/mysql-native/serializers/writer.js
@@ -57,6 +57,24 @@ writer.prototype.lcstring = function(s)
    return this;
 }
 
+writer.prototype.lcbits = function(s){
+    if(s instanceof Array){
+        this.lcnum(Math.ceil(s.length/8));
+        var placeValue = 1;
+        var num = 0;
+        for(var i=0;i<s.length;i++){
+            if(s[i]){
+                num += placeValue;
+            }
+            placeValue *= 2;
+        }
+        this.lcnum(num);
+    }else{
+        this.lcnum(1);
+        this.lcnum(s?1:0);
+    }
+}
+
 writer.prototype.add = function(s)
 {
    if (typeof s == "string")      // add string bufer


### PR DESCRIPTION
I fixed a couple of things and I thought you might want them.  The first is an issue with parsing very large numbers.  The parser was using the bit shift operator, which assumes a 32 bit integer.  Numbers that were larger than the maximum 32 bit integer were parsed incorrectly.  My change uses multiplication instead of bit shift, which causes long integers to be parsed correctly.  The second commit fixes some inconsistent punctuation and adds support for the bit field data type.
