### PR TITLE
Add support for MYSQL_TYPE_NEWDECIMAL

### DIFF
--- a/lib/mysql-native/commands/query.js
+++ b/lib/mysql-native/commands/query.js
@@ -42,6 +42,7 @@ function parseNumber(s, type) {
         break;
       case types.MYSQL_TYPE_FLOAT:
       case types.MYSQL_TYPE_DOUBLE:
+      case types.MYSQL_TYPE_NEWDECIMAL:
         return parseFloat(s)
         break;
     }
@@ -66,6 +67,7 @@ var type_parsers = {};
   type_parsers[types.MYSQL_TYPE_NEWDATE] = parseTime;
   type_parsers[types.MYSQL_TYPE_VARCHAR] = parseString;
   type_parsers[types.MYSQL_TYPE_BIT] = parseNumber;
+  type_parsers[types.MYSQL_TYPE_NEWDECIMAL] = parseNumber;
   //MYSQL_TYPE_NEWDECIMAL: 246,
   //MYSQL_TYPE_ENUM: 247,
   //MYSQL_TYPE_SET: 248,


### PR DESCRIPTION
It seems we just need to parse the strValue as a float and we can support TYPE_NEWDECIMAL.

Thanks,
Stephen
