### PR TITLE
Update lib/mysql-native/commands/execute.js

### DIFF
--- a/lib/mysql-native/commands/execute.js
+++ b/lib/mysql-native/commands/execute.js
@@ -96,6 +96,9 @@ function execPrepared(sql, parameters)
               if(typeof parameters[i] == "boolean" || (parameters[i] instanceof Array && parameters[i].every(function(x){return typeof x == 'boolean';}))){
                 packet.lcbits(parameters[i]);
               }
+              if(typeof parameters[i] == "string") {
+            	parameters[i] = this.client.charset.convertToBytes(parameters[i]);
+              }
               packet.lcstring(parameters[i].toString())
             }
           }
@@ -173,6 +176,7 @@ function execPrepared(sql, parameters)
             if (!null_bit_map[f])
             {
                 var value = r.unpackBinary(field.type, field.flags & field_flags.UNSIGNED);
+                if(typeof(value)=="string") value = this.client.charset.convertFromBytes(value);
                 this.store_column(row, field, value, use_hash);
             } else {
                 this.store_column(row, field, null, use_hash);


### PR DESCRIPTION
added UTF-8 support for both retrieving and storing strings
